### PR TITLE
removing cloned field

### DIFF
--- a/assets/js/youtubepicker.js
+++ b/assets/js/youtubepicker.js
@@ -23,15 +23,6 @@
 			var self   = this;
 			var offset = {};
 
-			if(self.options.cloneField){
-				self.clone = self.$field.clone(true);
-				self.$field.removeAttr('name');
-				self.clone.insertAfter(self.$field);
-				self.clone.hide()
-					.removeAttr('class id')
-					.addClass('youtubepicker-cloned-field');
-			}
-
 			$(self.template('panel')).insertAfter(self.$field);
 
 			self.$panel = $('#' + self.id);
@@ -87,10 +78,6 @@
 					e.preventDefault();
 
 					var data = $(this).closest('.youtubepicker-item').data('youtubepicker-item-data');
-					if(self.options.cloneField){
-						self.clone.val(data.vid);
-						data = $.extend({}, data, {clone: self.clone, term: self.term});
-					}
 					self.$field.trigger('itemSelected', data);
 					self.$panel.hide();
 				});
@@ -263,7 +250,6 @@
 		minChar: 3,
 		searchDelay: 2,
 		preview: true,
-		cloneField: true,
 		offset: {
 			x: 0, 
 			y: 0


### PR DESCRIPTION
Removing the cloned field that is used on the front end.

It does not appear to have any purpose that I can see? Tested a few things and it still works properly without it.

This is to fix an issue with acf conditional logic, where if there are multiple fields the ACF logic to run the conditional fields can not cope with it, and makes the youtube picker not work, this is to fix #20 